### PR TITLE
Fixed bug where PowerShell modules were not updating

### DIFF
--- a/Profile/Profile.ps1
+++ b/Profile/Profile.ps1
@@ -179,7 +179,7 @@ foreach ($module in $InstalledModules) {
     } else {    # An else is used here as we don't want to run the code below if it has just been checked because of the above if statement
         # If the module was last checked for an update more than the configured amount of days ago
         # If LastUpdateCheck -GT (LastUpdateCheck + moduleDefaultUpdateFrequency)
-        if (($JSONData.powershellModules | Where-Object Name -eq $module.Name).LastUpdateCheck -gt ($JSONData.powershellModules | Where-Object Name -eq $module.Name).LastUpdateCheck.AddDays($JSONConfig.PowerShell.moduleDefaultUpdateFrequency)) {
+        if ((Get-Date) -gt ($JSONData.powershellModules | Where-Object Name -eq $module.Name).LastUpdateCheck.AddDays($JSONConfig.PowerShell.moduleDefaultUpdateFrequency)) {
             # Start a job to check for an update
             Start-ModuleVersionCheck -ModuleName $module.Name
             $jobsCreated = $true # Used later during the job check

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ For **Windows Terminal** you'll want to insert the below into your desired profi
 
 For **VS Code** you will need to update the setting `terminal.integrated.fontFamily` to: `CaskaydiaCove Nerd Font Mono`. You can also provide a list: `'CaskaydiaCove Nerd Font Mono', Consolas, 'Courier New', monospace`.
 
-❗ If the glyphs aren't showing up, restart VS Code!
+> ❗If the glyphs aren't showing up, restart VS Code!
 
 ### Import The Profile
 

--- a/readme.md
+++ b/readme.md
@@ -12,16 +12,56 @@
 
 ## How To Use
 
-- 1️⃣ Clone the repository
-- 2️⃣ In a PowerShell console, navigate to the root of the cloned repository
-- 3️⃣ Run `Import-Profile.ps1`
+### Install Dependencies
+
+The terminal uses [Oh-My-Posh](https://ohmyposh.dev/) to jazz up the terminal. To install it:
+
+- Install [Oh My Posh](https://ohmyposh.dev/docs/installation/windows) by running `winget install JanDeDobbeleer.OhMyPosh -s winget`
+- Restart your terminal, and run: `oh-my-posh version`. If Oh My Posh cannot be found then restart your device and try again.
+
+We'll also want to install the PowerShell modules that are automatically imported into the profile.
+
+```powershell
+Install-Module Az, Terminal-Icons, posh-git
+```
+
+### Install Fonts
+
+The theme that I use uses glyphs which requires a Nerd Font to be installed. You can install a Nerd Font by running `oh-my-posh font install --user`.
+
+I personally choose `CascadiaCode`.
+
+We now need to configure our applications to use the fonts.
+
+For **Windows Terminal** you'll want to insert the below into your desired profiles: 
+
+```json
+"font": {
+  "face": "CaskaydiaCove Nerd Font Mono"
+}
+```
+
+**Or** you cna just use the appearance settings in the Windows Terminal settings.
+
+For **VS Code** you will need to update the setting `terminal.integrated.fontFamily` to: `CaskaydiaCove Nerd Font Mono`. You can also provide a list: `'CaskaydiaCove Nerd Font Mono', Consolas, 'Courier New', monospace`.
+
+❗ If the glyphs aren't showing up, restart VS Code!
+
+### Import The Profile
+
+Now that we have the PowerShell modules and fonts installed we can import the profile:
+
+- Clone the repository: `git clone https://github.com/MattDaines/PowerShell-Profile`
+- In a PowerShell console, navigate to the root of the cloned repository
+  - Running `ls`/`Get-ChildIdem` should show the `Import-Profile.ps1` file as well as the `Profile` directory
+- Run `Import-Profile.ps1` which copies the files to your `$PROFILE` directory
 
 ## Troubleshooting
 
 ### VS Code Terminal Is Not Rendering Foreground Text Correctly
 
-[Stak Overflow Reference](https://stackoverflow.com/questions/71890831/rendering-strange-in-vscode-terminal-with-oh-my-posh-v3)
+[Stack Overflow Reference](https://stackoverflow.com/questions/71890831/rendering-strange-in-vscode-terminal-with-oh-my-posh-v3)
 
-1) Open VS Code Settings via Ctrl+,
+1) Open VS Code Settings via `Ctrl + ,`
 2) Search for the item "Terminal > Integrated: Minimum Contrast Ratio"
 3) Set the value to 1 (from 4.5)


### PR DESCRIPTION
This pull request fixes a bug that meant that PowerShell module were not being updated after their default period of time.

The frontpage documentation has also been updated to help get setup from a relatively clean install.